### PR TITLE
Added option to disable global component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ function install (Vue, options) {
   }
 
   // Add a default breadcrumbs component
-  if (options.skipComponent !== true) {
+  if (options.registerComponent !== false) {
     Vue.component('breadcrumbs', Object.assign(defaults, options))
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,9 @@ function install (Vue, options) {
   }
 
   // Add a default breadcrumbs component
-  Vue.component('breadcrumbs', Object.assign(defaults, options))
+  if (options.skipComponent !== true) {
+    Vue.component('breadcrumbs', Object.assign(defaults, options))
+  }
 }
 
 export default {


### PR DESCRIPTION
This commit makes the global breadcrumbs component optional by setting options.skipComponent to true.

Due to the extensive nature of what I am doing I feel more comfortable creating my own component and working solely with this.$breadcrumbs. Having a globally namespaced component that I don't use is not ideal for me personally.

Example:
```
Vue.use(VueBreadcrumbs, {
  skipComponent: true
});
```

I did not build the dist files for this pull request or bump the version number.